### PR TITLE
utils.getValueByDotNotation(): Add null check

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -58,7 +58,7 @@ export class Utils {
         const arr = str.split('.')
         for (let i = 0, n = arr.length; i < n; ++i) {
             const property = arr[i]
-            if (property in obj) {
+            if (obj && property in obj) {
                 obj = obj[property]
             } else {
                 return


### PR DESCRIPTION
With *Savage Worlds*, I'm seeing this type of error quite often in the console:

```js
utils.js:61 Uncaught (in promise) TypeError: Cannot use 'in' operator to search for 'hasArcaneBackground' in null
    at Utils.getValueByDotNotation (utils.js:61:17)
    at change-log.js:273:36
    at Array.map (<anonymous>)
    at ChangeLog.getPreUpdateData (change-log.js:271:54)
    at Object.fn (change-log.js:69:26)
    at #call (foundry.js:730:20)
    at Hooks.call (foundry.js:712:38)
    at #preUpdateDocumentArray (foundry.js:13674:44)
    at async ClientDatabaseBackend._updateDocuments (foundry.js:13449:22)
    at async SwadeItem.updateDocuments (commons.js:8001:23)
    at async SwadeItem.update (commons.js:8098:23)
    at async SwadeItemSheetV2._onSubmit (foundry.js:6626:7)
    at async SwadeItemSheetV2.saveEditor (foundry.js:6773:5)
```

Also, thanks for the great module @Larkinabout :)

Edit: for anyone running into this, I went ahead and published this and a few other fixes in a fork for now at https://github.com/mhilbrunner/fvtt-change-log, see https://github.com/Larkinabout/fvtt-change-log/issues/17#issuecomment-2563289879