### PR TITLE
fix: null check

### DIFF
--- a/src/change-log.js
+++ b/src/change-log.js
@@ -286,7 +286,7 @@ export class ChangeLog {
         const modifiedByName = game.users.get(userId)?.name
 
         for (const key of Object.keys(flattenedObjects)) {
-            const { isEveryone, isGm, isPlayer } = this.#getAudience(documentType, actor.type, key)
+            const { isEveryone, isGm, isPlayer } = this.#getAudience(documentType, actor?.type, key)
 
             if (!isEveryone && !isGm && !isPlayer) continue
 


### PR DESCRIPTION
The hook on `preUpdateActiveEffect` can result in not finding an actor object, which causes an exception at the place where the safe access operator was added