### PR TITLE
Add setting to only log player-owned actors

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -19,6 +19,8 @@
     "changeLog.settings.playerPropertiesForm.hint": "Changes to log for the player",
     "changeLog.settings.showEquation.name": "Show Equation",
     "changeLog.settings.showEquation.hint": "For numerical changes, choose whether to show the equation on the chat card",
+    "changeLog.settings.onlyPlayerActors.name": "Only Player Actors",
+    "changeLog.settings.onlyPlayerActors.hint": "Only logs changes to actors that are owned by at least one player",
     "changeLog.settings.showRecipients.name": "Show Recipients",
     "changeLog.settings.showRecipients.hint": "Choose whether to show recipients on the chat card",
     "changeLog.settings.showSender.name": "Show Sender",

--- a/src/change-log.js
+++ b/src/change-log.js
@@ -109,6 +109,7 @@ export class ChangeLog {
             this.getPlayerProperties(),
             this.getShowEquation(),
             this.getShowRecipients(),
+            this.getOnlyPlayerActors(),
             this.getShowSender()
         ])
     }
@@ -139,6 +140,10 @@ export class ChangeLog {
 
     async getShowRecipients () {
         this.showRecipients = await Utils.getSetting('showRecipients')
+    }
+
+    async getOnlyPlayerActors () {
+        this.onlyPlayerActors = await Utils.getSetting('onlyPlayerActors')
     }
 
     async getShowSender () {
@@ -450,6 +455,10 @@ export class ChangeLog {
         const { actor, isEveryone, isGm, isPlayer } = whisperData
 
         if (!this.#isValidChange({ oldValue, newValue })) return
+
+        if (this.getOnlyPlayerActors() && actor && !actor.hasPlayerOwner) {
+            return;
+        }
 
         const content = await renderTemplate(
             TEMPLATE.CHAT_CARD,

--- a/src/settings.js
+++ b/src/settings.js
@@ -82,6 +82,16 @@ export const registerSettings = function () {
         onChange: () => { game.changeLog.getShowRecipients() }
     })
 
+    game.settings.register(MODULE.ID, 'onlyPlayerActors', {
+        name: game.i18n.localize('changeLog.settings.onlyPlayerActors.name'),
+        hint: game.i18n.localize('changeLog.settings.onlyPlayerActors.hint'),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: false,
+        onChange: () => { game.changeLog.getOnlyPlayerActors() }
+    })
+
     game.settings.register(MODULE.ID, 'gmProperties', {
         name: 'GM Properties',
         scope: 'world',


### PR DESCRIPTION
This adds a new (disabled by default) module setting to only log changes to actors that have at least one player (non-GM) owner.

I've never found much use in logging what I'm doing as the GM.