### PR TITLE
More minimalist chat cards

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -1,5 +1,6 @@
 {
     "changeLog.chatTabs.hint": "Messages sent by the Change Log module.",
+    "changelog.change": "Change: {change}",
     "changeLog.empty": "–",
     "changeLog.modifiedBy": "Modified By",
     "changeLog.settings.everyoneActorTypesForm.name": "Actor Types for Everyone",

--- a/src/change-log.js
+++ b/src/change-log.js
@@ -454,7 +454,6 @@ export class ChangeLog {
         const content = await renderTemplate(
             TEMPLATE.CHAT_CARD,
             {
-                document1Name,
                 document2Name,
                 propertyName: Utils.getPropertyName(`${documentType}.${key}`),
                 oldValue: Utils.getPropertyValue(oldValue),
@@ -468,7 +467,8 @@ export class ChangeLog {
         const owners = this.#getOwners(actor)
         const gms = this.#getGms()
 
-        const speaker = { alias: 'Change Log' }
+        const name = document1Name ? document1Name : "???";
+        const speaker = { alias: game.i18n.format('changelog.change', {change: name}) }
 
         let whisper = null
         if (!isEveryone) {

--- a/src/change-log.js
+++ b/src/change-log.js
@@ -468,7 +468,13 @@ export class ChangeLog {
         const gms = this.#getGms()
 
         const name = document1Name ? document1Name : "???";
-        const speaker = { alias: game.i18n.format('changelog.change', {change: name}) }
+        let speaker = null;
+        if (actor) {
+            speaker = ChatMessage.getSpeaker({ actor: actor });
+        }
+        if (!speaker) {
+            speaker = { alias: game.i18n.format('changelog.change', { change: name }) };
+        }
 
         let whisper = null
         if (!isEveryone) {

--- a/templates/chat-card.hbs
+++ b/templates/chat-card.hbs
@@ -1,5 +1,4 @@
 <div class="change-log-card-content" data-tooltip="{{tooltip}}">
-    {{#if document1Name}}<span class="change-log-card-document1">{{document1Name}}</span>{{/if}}
     {{#if document2Name}}<span class="change-log-card-document2">{{document2Name}}</span>{{/if}}
     {{#if propertyName}}<span class="change-log-card-property">{{propertyName}}</span>{{/if}}
     <div class="change-log-card-values">


### PR DESCRIPTION
This makes the created chat cards more minimalist, in order to fit more onto the screen.

Instead of each message having a title of "Change Log", this makes the changed document (usually actor) name, and also uses the actor as speaker for the chat card. This saves a line and also makes it more clear at a glance.

This may indirectly help with https://github.com/Larkinabout/fvtt-change-log/issues/6, either fully or at least partly. :)

## Before

![image](https://github.com/user-attachments/assets/afa8032a-0cc2-4609-9901-48936f3f8aae)

## After

![image](https://github.com/user-attachments/assets/8aa769ab-c8c5-431a-a5d8-7329418676a2)
